### PR TITLE
DEPRECATED - [Setup.sh] Fixed the assumption of Clang directories

### DIFF
--- a/Util/BuildTools/Setup.sh
+++ b/Util/BuildTools/Setup.sh
@@ -51,14 +51,14 @@ fi
 
 source $(dirname "$0")/Environment.sh
 
-command -v /usr/bin/clang++-$CARLA_LLVM_VERSION_MAJOR >/dev/null 2>&1 || {
+command -v clang++-$CARLA_LLVM_VERSION_MAJOR >/dev/null 2>&1 || {
   echo >&2 "clang-$CARLA_LLVM_VERSION_MAJOR is required, but it's not installed.";
   exit 1;
 }
 
 CXX_TAG=c$CARLA_LLVM_VERSION_MAJOR
-export CC=/usr/bin/clang-$CARLA_LLVM_VERSION_MAJOR
-export CXX=/usr/bin/clang++-$CARLA_LLVM_VERSION_MAJOR
+export CC=`command -v clang-$CARLA_LLVM_VERSION_MAJOR`
+export CXX=`command -v clang++-$CARLA_LLVM_VERSION_MAJOR`
 
 # Convert comma-separated string to array of unique elements.
 IFS="," read -r -a PY_VERSION_LIST <<< "${PY_VERSION_LIST}"


### PR DESCRIPTION
I didn't notice the 'dev' branch, 
I will keep this just for historical records. (So It will not be merged with the original repo)

Original Issue:

Checklist:

  - [ ] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

#### Description


The initial behaviour of the `Setup.sh` assumes that LLVM/Clang is located in the `/usr/bin` directory which can be wrong in some distros like for example, Gentoo installs llvm/clang files in `/usr/lib/llvm/16/bin/` and this could be applied on other Linux distros and in general is a better practice don't assume where it's located the files.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):**  Gentoo
  * **Python version(s):**  Python 3.11.4
  * **Unreal Engine version(s):**  4.26

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
